### PR TITLE
Bump hibernate.version from 6.6.4.Final to 7.0.0.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
         <!-- Persistence -->
         <spring-data.version>2024.1.1</spring-data.version>
-        <hibernate.version>6.6.4.Final</hibernate.version>
+        <hibernate.version>7.0.0.Final</hibernate.version>
         <hibernate-validator.version>8.0.2.Final</hibernate-validator.version>
         <hsqldb.version>2.7.4</hsqldb.version>
         <h2database.version>2.3.232</h2database.version>


### PR DESCRIPTION
Bumps `hibernate.version` from 6.6.4.Final to 7.0.0.Final.

Updates `org.hibernate.orm:hibernate-core` from 6.6.4.Final to 7.0.0.Final
- [Release notes](https://github.com/hibernate/hibernate-orm/releases)
- [Changelog](https://github.com/hibernate/hibernate-orm/blob/main/changelog.txt)
- [Commits](https://github.com/hibernate/hibernate-orm/compare/6.6.4...7.0.0)

Updates `org.hibernate.orm:hibernate-jcache` from 6.6.4.Final to 7.0.0.Final
- [Release notes](https://github.com/hibernate/hibernate-orm/releases)
- [Changelog](https://github.com/hibernate/hibernate-orm/blob/main/changelog.txt)
- [Commits](https://github.com/hibernate/hibernate-orm/compare/6.6.4...7.0.0)

---
updated-dependencies:
- dependency-name: org.hibernate.orm:hibernate-core dependency-version: 7.0.0.Final dependency-type: direct:production update-type: version-update:semver-major
- dependency-name: org.hibernate.orm:hibernate-jcache dependency-version: 7.0.0.Final dependency-type: direct:production update-type: version-update:semver-major ...